### PR TITLE
Modified form_group_tag helper with alternative

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,11 +4,11 @@ module ApplicationHelper
     'gianpietro1'
   end
 
-  def form_group_tag(errors, &block)
+  def form_group_class(errors)
     if errors.any?
-      content_tag :div, capture(&block), class: 'form-group has-error'
+      "form-group has-error"
     else
-      content_tag :div, capture(&block), class: 'form-group'
+      "form-group"
     end
   end
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -10,14 +10,14 @@
     </div>
   <% end %>
 
-  <%= form_group_tag(post.errors[:title]) do %>
+  <div class="<%= form_group_class(post.errors[:title])%>">
       <%= f.label :title %>
       <%= f.text_field :title, class: 'form-control', placeholder: "Enter post title" %>
-  <% end %>
-  <%= form_group_tag(post.errors[:body]) do %>
+  </div>
+  <div class="<%= form_group_class(post.errors[:body])%>">
       <%= f.label :body %>
       <%= f.text_area :body, rows: 8, class: 'form-control', placeholder: "Enter post body" %>
-  <% end %>
+  </div>
   <div class="form-group">
     <%= f.submit "Save", class: 'btn btn-success' %>
   </div>


### PR DESCRIPTION
This alternative, which uses basic interpolation in the helper instead of the content_tag method, is shorter and straightforward.
