### PR TITLE
markdown@posts alternative

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,4 +9,23 @@ class Post < ActiveRecord::Base
   validates :body, length: {minimum: 20}, presence: true
   validates :topic, presence: true
   validates :user, presence: true
+
+  def markdown_title
+    render_as_markdown title
+  end
+
+  def markdown_body
+    render_as_markdown body
+  end
+
+  private
+
+  def render_as_markdown(text)
+    renderer = Redcarpet::Render::HTML.new
+    extensions = {fenced_code_blocks: true}
+    redcarpet = Redcarpet::Markdown.new(renderer, extensions)
+    (redcarpet.render text).html_safe
+  end
+
+
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,8 +1,8 @@
-<h1><%= markdown @post.title %></h1>
+<h1><%= @post.markdown_title %></h1>
 
 <div class="row">
   <div class="col-md-8">
-    <p><%= markdown @post.body %></p>
+    <p><%= @post.markdown_body %></p>
   </div>
   <div class="col-md-4">
       <%if policy(@post).edit? %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -11,7 +11,7 @@
     <div class="media">
       <div class="media-body">
         <h4 class="media-heading">
-          <%= link_to (markdown post.title), [@topic,post] %>
+          <%= link_to (post.markdown_title), [@topic,post] %>
         </h4>
         <small>
           submitted <%= time_ago_in_words(post.created_at) %> ago by <%= post.user.name %><br/>


### PR DESCRIPTION
Moved redcarpet markdown code from the helper to the model; created methods there for title & body, and called them from the views.
